### PR TITLE
Remove mutate deck tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
                 return;
             }
             const cardTags = card.Tags || card.tags; 
-            if (cardTags && cardTags.trim() !== "" && cardTags !== "Other" && cardTags !== "B - The Big Top" && cardTags !== "WU - Studies" && cardTags !== "WU - Studies (Lessons)") {
+            if (cardTags && cardTags.trim() !== "" && cardTags !== "Other" && cardTags !== "B - The Big Top" && cardTags !== "WUR - Mutate" && cardTags !== "WU - Studies" && cardTags !== "WU - Studies (Lessons)") {
                 themes.add(cardTags.trim());
             }
         });


### PR DESCRIPTION
Since mutate isn't implemented I'm removing this tag from consideration. There's still going to be packs that have mutate cards in them but we'll have to deal with them as they pop up.