### PR TITLE
No more maybeboard cards in decklist

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,6 +615,10 @@ input[type="radio"]:checked + label.pack-radio-label {
         const deck = [];
         currentCubeData.forEach(card => {
             const cardTags = card.Tags || card.tags; 
+            const cardMaybe = card.Maybe || card.maybeboard
+            if (cardMaybe && cardMaybe == "true") {
+                return;
+            }
             if (cardTags === packSelections.pack1 || cardTags === packSelections.pack2) {
                 const cardName = card.Name || card.name;
                 if (cardName && cardName.trim() !== "") {


### PR DESCRIPTION
Added a check to skip adding cards to decklist if they are in the maybeboard. We were doing this at the tag check to populate the theme list but I forgot to replicate it in the decklist creation.