### PR TITLE
Update card image dimensions

### DIFF
--- a/card-display.js
+++ b/card-display.js
@@ -61,22 +61,22 @@ function preloadCardImages(cardNames) {
  * Create a standard card image element with consistent styling
  * @param {string} cardName - The name of the card
  * @param {Object} options - Styling options
- * @param {string} options.width - Image width (default: '110px')
- * @param {string} options.height - Image height (default: '156px')
+ * @param {string} options.width - Image width (default: '122px')
+ * @param {string} options.height - Image height (default: '170px')
  * @param {boolean} options.hoverPreview - Whether to attach hover preview (default: true)
  * @param {string} options.className - Additional CSS class (default: 'decklist-card-thumb')
  * @returns {HTMLImageElement} The created image element
  */
 function createCardImage(cardName, options = {}) {
     const {
-        width = '110px',
-        height = '156px',
+        width = '122px',
+        height = '170px',
         hoverPreview = true,
         className = 'decklist-card-thumb'
     } = options;
 
     const img = document.createElement('img');
-    img.src = `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(cardName)}&format=image`;
+    img.src = `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(cardName)}&format=image&version=normal`;
     img.alt = cardName;
     img.title = cardName;
     img.style.width = width;

--- a/commander-features.js
+++ b/commander-features.js
@@ -31,8 +31,8 @@ function renderCommanderZone(commanders) {
         img.src = `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(cardName)}&format=image`;
         img.alt = cardName;
         img.title = cardName;
-        img.style.width = '110px';
-        img.style.height = '156px';
+        img.style.width = '122px';
+        img.style.height = '170px';
         img.style.objectFit = 'cover';
         img.style.border = '2px solid #facc15';
         img.style.borderRadius = '4px';
@@ -85,8 +85,8 @@ function renderKoffersStep(koffersPool, onSelect) {
         img.src = `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(cardName)}&format=image`;
         img.alt = cardName;
         img.title = cardName;
-        img.style.width = '90px';
-        img.style.height = '128px';
+        img.style.width = '122px';
+        img.style.height = '170px';
         img.style.marginBottom = '8px';
         attachCardHoverPreview(img, cardName);
 
@@ -212,7 +212,7 @@ async function renderFixingLandsStep(fixingPool, deck, onSelect, packSelections)
             btn.style.cursor = 'pointer';
             btn.style.position = 'relative';
 
-            const img = createCardImage(cardName, { width: '110px', height: '156px' });
+            const img = createCardImage(cardName, { width: '122px', height: '170px' });
             btn.appendChild(img);
 
             // Add a checkmark overlay if selected
@@ -352,7 +352,7 @@ function promptBasicLandToRemove(basicsDeck, current, total) {
             btn.style.flexDirection = 'column';
             btn.style.alignItems = 'center';
 
-            const img = createCardImage(name, { width: '90px', height: '128px', hoverPreview: false });
+            const img = createCardImage(name, { width: '122px', height: '170px', hoverPreview: false });
             img.style.marginBottom = '6px';
             btn.appendChild(img);
 

--- a/visual-display.js
+++ b/visual-display.js
@@ -114,8 +114,8 @@ function createCardWrapper(cardName, count, idx, cardsPerRow) {
     cardWrapper.style.marginLeft = idx % cardsPerRow === 0 ? '0' : '-32px'; // overlap by 32px
 
     const cardImg = createCardImage(cardName, {
-        width: '110px',
-        height: '156px',
+        width: '122px',
+        height: '170px',
         className: 'decklist-card-thumb'
     });
     cardImg.style.border = '2px solid #222';


### PR DESCRIPTION
Modified scryfall URLs to force normal image quality and resized images so they are evenly divided by 4. It's not perfect, but it does make the images a bit more readable without having to hover over them.