### PR TITLE
ForKvatch Draft Changes

### DIFF
--- a/commander-features.js
+++ b/commander-features.js
@@ -232,8 +232,8 @@ async function renderFixingLandsStep(fixingPool, deck, onSelect, packSelections)
                     check.style.display = 'none';
                 } else {
                     const selected = fixingDiv.querySelectorAll('.selected');
-                    if (selected.length >= 6) {
-                        showMessage('You can only select up to 6 fixing lands.', 'error', 2000);
+                    if (selected.length >= 4) {
+                        showMessage('You can only select up to 4 fixing lands.', 'error', 2000);
                         return;
                     }
                     btn.classList.add('selected');
@@ -258,7 +258,7 @@ async function renderFixingLandsStep(fixingPool, deck, onSelect, packSelections)
 
     function updateSelected() {
         const selected = fixingDiv.querySelectorAll('.selected');
-        confirmBtn.disabled = selected.length > 6;
+        confirmBtn.disabled = selected.length > 4;
     }
     updateSelected();
 

--- a/pack-selection.js
+++ b/pack-selection.js
@@ -25,8 +25,8 @@ function displayPackChoices(packNumber, globals) {
     const selectedCube = getSelectedCube(cubeSelect.value, cubes);
     const isCommanderCube = selectedCube && selectedCube.isCommander;
 
-    // Use 10 packs for commander cube, 3 for others
-    const packsToOffer = isCommanderCube ? 10 : 3;
+    // Use 20 packs for commander cube, 3 for others
+    const packsToOffer = isCommanderCube ? 20 : 3;
 
     if (packNumber === 1) {
         packSelections.pack1 = null; 


### PR DESCRIPTION
Talked to ForKvatch today, he said he's changed the way he drafts his cube but hadn't updated the description. 

- Limit fixing lands to 4, down from 6
- Show an initial 20 packs to pick from, 19 choices for second pack

This PR implements both of those changes.