### PR TITLE
Add HTTP headers to Scryfall API requests

### DIFF
--- a/cubes/.cube_update.ps1
+++ b/cubes/.cube_update.ps1
@@ -3,10 +3,16 @@ function Remove-Diacritics{
     return [Text.Encoding]::ASCII.GetString([Text.Encoding]::GetEncoding("Cyrillic").GetBytes($inputString))
 }
 
+# HTTP headers required by Scryfall API
+$headers = @{
+    "User-Agent" = "RossCube/1.0"
+    "Accept"     = "application/json"
+}
+
 # Fetch Scryfall oracle cards
 $bulkUrl = "https://api.scryfall.com/bulk-data"
-$oracleData = (Invoke-RestMethod -Uri $bulkUrl).data | Where-Object { $_.type -eq "oracle_cards" }
-$scryfallCards = Invoke-RestMethod -Uri $oracleData.download_uri
+$oracleData = (Invoke-RestMethod -Uri $bulkUrl -Headers $headers).data | Where-Object { $_.type -eq "oracle_cards" }
+$scryfallCards = Invoke-RestMethod -Uri $oracleData.download_uri -Headers $headers
 
 # Build a hashtable of Scryfall cards for fast lookup
 $scryHash = @{}


### PR DESCRIPTION
## Summary
Updated the cube update script to include proper HTTP headers when making requests to the Scryfall API, improving API compliance and reliability.

## Changes
- Added HTTP headers object with `User-Agent` and `Accept` fields required by Scryfall API
- Applied headers to both bulk data endpoint request and oracle cards download request
- User-Agent identifies the client as "RossCube/1.0"
- Accept header explicitly requests JSON response format

## Details
The Scryfall API benefits from proper HTTP headers being included in requests. This change ensures the script follows API best practices by:
- Identifying the client making the request via User-Agent
- Explicitly declaring the expected response format (application/json)
- Improving compatibility and reducing potential rate-limiting issues

https://claude.ai/code/session_01W9nrZ1TvN1MknFyrT2Y4aU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data fetching reliability with enhanced HTTP header support for API communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->